### PR TITLE
fix: check that output object is not null before trying to destructur…

### DIFF
--- a/simple-white-calendar.widget/simple-white-calendar.jsx
+++ b/simple-white-calendar.widget/simple-white-calendar.jsx
@@ -113,10 +113,12 @@ export const render = ({ output, error }) => {
   }
 
   const s = parse(output);
-  return (
-    <div>
-      {header(...s.headers)}
-      {table(s.tableHeaderRow, s.tableBodyRows, s.today)}
-    </div>
-  );
+  if(output){
+    return (
+      <div>
+        {header(...s.headers)}
+        {table(s.tableHeaderRow, s.tableBodyRows, s.today)}
+      </div>
+    );
+  }
 };

--- a/simple-white-calendar.widget/simple-white-calendar.jsx
+++ b/simple-white-calendar.widget/simple-white-calendar.jsx
@@ -112,8 +112,8 @@ export const render = ({ output, error }) => {
     return <p>output is not defined</p>;
   }
 
-  const s = parse(output);
   if(output){
+  const s = parse(output);
     return (
       <div>
         {header(...s.headers)}


### PR DESCRIPTION
Fixes issue that caused breakage.

This bug was initially reported in issue #2 

Add: simple if statement that checks for truthy.  If object is empty, then do nothing.

Previous bug was triggered because the output object was empty. Any further processing on this empty object will naturally cause runtime errors. 